### PR TITLE
拆分单个设备单个连接，改为同一个设备可以创建不同UUID的连接通道。

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,12 +223,13 @@ BTManager.getInstance().unregisterObserver(observer);
 
 ### 连接
 
-1. 建立连接
+1. 建立指定设备指定UUID的连接
 
 ```
-connection = BTManager.getInstance().createConnection(device, observer);//观察者监听连接状态
-//如果传null，默认使用{@link #SPP_UUID}连接
-connection.connect(uuid, new ConnectCallback() {
+//UUIDWrapper.useDefault()，使用默认的UUID(00001101-0000-1000-8000-00805f9b34fb)
+//UUIDWrapper.useCustom()，自定义UUID
+connection = BTManager.getInstance().createConnection(device, UUIDWrapper.useDefault(), observer);//观察者监听连接状态
+connection.connect(new ConnectCallback() {
     @Override
     public void onSuccess() {
       
@@ -244,14 +245,14 @@ connection.connect(uuid, new ConnectCallback() {
 2. 断开连接，还可再次连接
 
 ```
-BTManager.getInstance().disconnectConnection(device);//断开指定连接
+BTManager.getInstance().disconnectConnection(device, UUIDWrapper.useDefault());//断开指定设备的指定UUID的连接
 //BTManager.getInstance().disconnectAllConnections();//断开所有连接
 ```
 
 3. 释放连接，不可重连，需要重新建立连接
 
 ```
-BTManager.getInstance().releaseConnection(device);//释放指定连接
+BTManager.getInstance().releaseConnection(device, UUIDWrapper.useDefault());//释放指定设备的指定UUID的连接
 //BTManager.getInstance().releaseAllConnections();//释放所有连接
 ```
 

--- a/app/src/main/java/cn/wandersnail/btsppexample/MainActivity.java
+++ b/app/src/main/java/cn/wandersnail/btsppexample/MainActivity.java
@@ -13,6 +13,7 @@ import cn.wandersnail.bluetooth.BTManager;
 import cn.wandersnail.bluetooth.ConnectCallback;
 import cn.wandersnail.bluetooth.Connection;
 import cn.wandersnail.bluetooth.EventObserver;
+import cn.wandersnail.bluetooth.UUIDWrapper;
 
 /**
  * date: 2020/5/7 10:36
@@ -21,22 +22,22 @@ import cn.wandersnail.bluetooth.EventObserver;
 public class MainActivity extends AppCompatActivity implements EventObserver {
     private Connection connection;
     private TextView tvLog;
-    
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         tvLog = findViewById(R.id.tvLog);
         BluetoothDevice device = getIntent().getParcelableExtra("device");
-        connection = BTManager.getInstance().createConnection(device, this);
+        connection = BTManager.getInstance().createConnection(device, UUIDWrapper.useDefault(), this);
         if (connection == null) {
             finish();
             return;
         }
-        connection.connect(null, new ConnectCallback() {
+        connection.connect(new ConnectCallback() {
             @Override
             public void onSuccess() {
-                
+
             }
 
             @Override
@@ -49,12 +50,12 @@ public class MainActivity extends AppCompatActivity implements EventObserver {
             if (connection.isConnected()) {
                 if (!etMsg.getText().toString().isEmpty()) {
                     connection.write(null, etMsg.getText().toString().getBytes(), (device1, tag, value, result) -> {
-                        
+
                     });
                 }
             }
         });
     }
-    
-    
+
+
 }

--- a/app/src/main/java/cn/wandersnail/btsppexample/MainActivityKt.kt
+++ b/app/src/main/java/cn/wandersnail/btsppexample/MainActivityKt.kt
@@ -2,42 +2,49 @@ package cn.wandersnail.btsppexample
 
 import android.bluetooth.BluetoothDevice
 import android.os.Bundle
+import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import cn.wandersnail.bluetooth.BTManager
-import cn.wandersnail.bluetooth.ConnectCallback
-import cn.wandersnail.bluetooth.Connection
-import cn.wandersnail.bluetooth.EventObserver
+import cn.wandersnail.bluetooth.*
+import cn.wandersnail.commons.helper.WifiHelper
 import cn.wandersnail.commons.poster.RunOn
 import cn.wandersnail.commons.poster.ThreadMode
 import cn.wandersnail.commons.util.ToastUtils
 import kotlinx.android.synthetic.main.activity_main.*
+import java.util.*
 
-class MainActivityKt : AppCompatActivity(), EventObserver {
+class MainActivityKt : AppCompatActivity, EventObserver {
     private var connection: Connection? = null
+
+    constructor()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         val device: BluetoothDevice? = intent.getParcelableExtra("device")
-        if (device == null ) {
+        if (device == null) {
             finish()
             return
         }
-        connection = BTManager.getInstance().createConnection(device, this)
-        if (connection == null ) {
+        connection =
+            BTManager.getInstance().createConnection(
+                device,
+                UUIDWrapper.useDefault(),
+                this
+            )
+        if (connection == null) {
             finish()
             return
         }
-        connection!!.connect(null, object : ConnectCallback {
+        connection!!.connect(object : ConnectCallback {
             override fun onSuccess() {
-                
+
             }
 
             override fun onFail(errMsg: String, e: Throwable?) {
                 runOnUiThread { tvLog.append("连接失败\n") }
             }
         })
-        btnSend.setOnClickListener { 
+        btnSend.setOnClickListener {
             if (connection?.isConnected == true) {
                 if (etMsg.text?.isNotEmpty() == true) {
                     connection?.write(null, etMsg.text!!.toString().toByteArray(), null)
@@ -54,7 +61,7 @@ class MainActivityKt : AppCompatActivity(), EventObserver {
     }
 
     override fun onWrite(device: BluetoothDevice, tag: String, value: ByteArray, result: Boolean) {
-        
+
     }
 
     @RunOn(ThreadMode.MAIN)

--- a/library/src/main/java/cn/wandersnail/bluetooth/Connection.java
+++ b/library/src/main/java/cn/wandersnail/bluetooth/Connection.java
@@ -12,7 +12,6 @@ import java.util.UUID;
  * author: zengfansheng
  */
 public abstract class Connection {
-    public static final UUID SPP_UUID = UUID.fromString("00001101-0000-1000-8000-00805f9b34fb");
 
     /**
      * 未连接
@@ -48,7 +47,7 @@ public abstract class Connection {
      * 连接是否已释放
      */
     public abstract boolean isReleased();
-    
+
     /**
      * 是否已连接
      */
@@ -60,10 +59,9 @@ public abstract class Connection {
     /**
      * 指定连接的UUID
      *
-     * @param uuid     如果传null，默认使用{@link #SPP_UUID}连接
      * @param callback 连接回调
      */
-    public abstract void connect(UUID uuid, ConnectCallback callback);
+    public abstract void connect(ConnectCallback callback);
 
     /**
      * 断开连接

--- a/library/src/main/java/cn/wandersnail/bluetooth/SocketConnection.java
+++ b/library/src/main/java/cn/wandersnail/bluetooth/SocketConnection.java
@@ -22,14 +22,20 @@ class SocketConnection {
     private final BluetoothDevice device;
     private OutputStream outStream;
     private final ConnectionImpl connection;
-    
-    SocketConnection(ConnectionImpl connection, BTManager btManager, BluetoothDevice device, UUID uuid, ConnectCallback callback) {
+
+    /**
+     * UUID缓存
+     */
+    private final UUIDWrapper uuidWrapper;
+
+    SocketConnection(ConnectionImpl connection, BTManager btManager, BluetoothDevice device, UUIDWrapper uuidWrapper, ConnectCallback callback) {
         this.device = device;
         this.connection = connection;
+        this.uuidWrapper = uuidWrapper;
         BluetoothSocket tmp;
         try {
             connection.changeState(Connection.STATE_CONNECTING, false);
-            tmp = device.createRfcommSocketToServiceRecord(uuid == null ? Connection.SPP_UUID : uuid);
+            tmp = device.createRfcommSocketToServiceRecord(uuidWrapper.getUuid());
         } catch (IOException e) {
             try {
                 Method method = device.getClass().getMethod("createRfcommSocket", new Class[]{int.class});
@@ -108,7 +114,7 @@ class SocketConnection {
             onWriteFail("Write failed: OutputStream is null or connection is released", data);
         }
     }
-    
+
     private void onWriteFail(String msg, WriteData data) {
         if (BTManager.isDebugMode) {
             Log.w(BTManager.DEBUG_TAG, msg);
@@ -119,7 +125,7 @@ class SocketConnection {
             data.callback.onWrite(device, data.tag, data.value, false);
         }
     }
-    
+
     void close() {
         if (socket != null) {
             try {
@@ -130,11 +136,11 @@ class SocketConnection {
             }
         }
     }
-    
+
     boolean isConnected() {
         return socket != null && socket.isConnected();
     }
-    
+
     static class WriteData {
         String tag;
         byte[] value;

--- a/library/src/main/java/cn/wandersnail/bluetooth/UUIDWrapper.java
+++ b/library/src/main/java/cn/wandersnail/bluetooth/UUIDWrapper.java
@@ -1,0 +1,49 @@
+package cn.wandersnail.bluetooth;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.UUID;
+
+/**
+ * @author xzh
+ * Time: 2022/11/03 11:23
+ * Description: uuid 包装
+ */
+public class UUIDWrapper {
+
+    public static final UUID SPP_UUID = UUID.fromString("00001101-0000-1000-8000-00805f9b34fb");
+
+    private UUIDWrapper() {
+    }
+
+    @NonNull
+    private UUID uuid = SPP_UUID;
+
+    @NonNull
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    /**
+     * 使用默认的UUID 默认使用{@link #SPP_UUID}连接
+     *
+     * @return 默认UUID包装器
+     */
+    public static UUIDWrapper useDefault() {
+        return new UUIDWrapper();
+    }
+
+    /**
+     * 使用自定义UUID连接
+     *
+     * @param uuid 自定义UUID
+     * @return UUID包装器
+     */
+    public static UUIDWrapper useCustom(@NonNull UUID uuid) {
+        UUIDWrapper wrapper = new UUIDWrapper();
+        wrapper.uuid = uuid;
+        return wrapper;
+    }
+
+}


### PR DESCRIPTION
可以对同一个设备，根据不同UUID创建不同的连接，并且同时维持这个设备不同的连接。

**使用场景**
如蓝牙耳机设备有两个不同的UUID，一个是OTA的UUID，一个是默认的UUID，需要同时保持这两个连接。

注意：不能对同一设备在同一时间建立两个连接，不然可能会连接失败read failed, socket might closed or timeout, read ret: -1。需要错开时间，比如建立完第一个后，几秒后建立第二个。